### PR TITLE
Made a few small improvements

### DIFF
--- a/NBTExplorer/Model/DirectoryDataNode.cs
+++ b/NBTExplorer/Model/DirectoryDataNode.cs
@@ -22,6 +22,11 @@ namespace NBTExplorer.Model
             }
         }
 
+        public string NodeDirPath
+        {
+            get { return _path; }
+        }
+
         public override string NodePathName
         {
             get

--- a/NBTExplorer/Windows/MainForm.Designer.cs
+++ b/NBTExplorer/Windows/MainForm.Designer.cs
@@ -31,42 +31,52 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemOpen = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemOpenFolder = new System.Windows.Forms.ToolStripMenuItem();
             this._menuItemOpenMinecraftSaveFolder = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this._menuItemSave = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemRefresh = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this._menuItemRecentFiles = new System.Windows.Forms.ToolStripMenuItem();
             this._menuItemRecentFolders = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+            this._menuItemExit = new System.Windows.Forms.ToolStripMenuItem();
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemCut = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemCopy = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemPaste = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            this._menuItemRename = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemEditValue = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemDelete = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+            this._menuItemMoveUp = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemMoveDown = new System.Windows.Forms.ToolStripMenuItem();
             this.searchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemFind = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemFindNext = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
             this.replaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
+            this.findBlockToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this._menuItemAbout = new System.Windows.Forms.ToolStripMenuItem();
             this.imageList1 = new System.Windows.Forms.ImageList(this.components);
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-            this.BottomToolStripPanel = new System.Windows.Forms.ToolStripPanel();
-            this.TopToolStripPanel = new System.Windows.Forms.ToolStripPanel();
-            this.RightToolStripPanel = new System.Windows.Forms.ToolStripPanel();
-            this.LeftToolStripPanel = new System.Windows.Forms.ToolStripPanel();
-            this.ContentPanel = new System.Windows.Forms.ToolStripContentPanel();
-            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.testToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._buttonOpen = new System.Windows.Forms.ToolStripButton();
             this._buttonOpenFolder = new System.Windows.Forms.ToolStripButton();
             this._buttonSave = new System.Windows.Forms.ToolStripButton();
             this._buttonRefresh = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this._buttonCut = new System.Windows.Forms.ToolStripButton();
             this._buttonCopy = new System.Windows.Forms.ToolStripButton();
             this._buttonPaste = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this._buttonRename = new System.Windows.Forms.ToolStripButton();
             this._buttonEdit = new System.Windows.Forms.ToolStripButton();
             this._buttonDelete = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this._buttonAddTagByte = new System.Windows.Forms.ToolStripButton();
             this._buttonAddTagShort = new System.Windows.Forms.ToolStripButton();
             this._buttonAddTagInt = new System.Windows.Forms.ToolStripButton();
@@ -78,25 +88,17 @@
             this._buttonAddTagString = new System.Windows.Forms.ToolStripButton();
             this._buttonAddTagList = new System.Windows.Forms.ToolStripButton();
             this._buttonAddTagCompound = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this._buttonFindNext = new System.Windows.Forms.ToolStripButton();
-            this._menuItemOpen = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemOpenFolder = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemSave = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemRefresh = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemExit = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemCut = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemCopy = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemPaste = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemRename = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemEditValue = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemDelete = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemMoveUp = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemMoveDown = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemFind = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemFindNext = new System.Windows.Forms.ToolStripMenuItem();
-            this._menuItemAbout = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-            this.findBlockToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.BottomToolStripPanel = new System.Windows.Forms.ToolStripPanel();
+            this.TopToolStripPanel = new System.Windows.Forms.ToolStripPanel();
+            this.RightToolStripPanel = new System.Windows.Forms.ToolStripPanel();
+            this.LeftToolStripPanel = new System.Windows.Forms.ToolStripPanel();
+            this.ContentPanel = new System.Windows.Forms.ToolStripContentPanel();
+            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.testToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
+            this._menuItemOpenInExplorer = new System.Windows.Forms.ToolStripMenuItem();
             this._nodeTree = new NBTExplorer.Vendor.MultiSelectTreeView.MultiSelectTreeView();
             this.menuStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
@@ -122,6 +124,8 @@
             this._menuItemOpen,
             this._menuItemOpenFolder,
             this._menuItemOpenMinecraftSaveFolder,
+            this.toolStripSeparator12,
+            this._menuItemOpenInExplorer,
             this.toolStripSeparator3,
             this._menuItemSave,
             this._menuItemRefresh,
@@ -134,38 +138,80 @@
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "&File";
             // 
+            // _menuItemOpen
+            // 
+            this._menuItemOpen.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemOpen.Image")));
+            this._menuItemOpen.Name = "_menuItemOpen";
+            this._menuItemOpen.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
+            this._menuItemOpen.Size = new System.Drawing.Size(233, 22);
+            this._menuItemOpen.Text = "&Open...";
+            // 
+            // _menuItemOpenFolder
+            // 
+            this._menuItemOpenFolder.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemOpenFolder.Image")));
+            this._menuItemOpenFolder.Name = "_menuItemOpenFolder";
+            this._menuItemOpenFolder.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            | System.Windows.Forms.Keys.O)));
+            this._menuItemOpenFolder.Size = new System.Drawing.Size(233, 22);
+            this._menuItemOpenFolder.Text = "Open &Folder...";
+            // 
             // _menuItemOpenMinecraftSaveFolder
             // 
             this._menuItemOpenMinecraftSaveFolder.Name = "_menuItemOpenMinecraftSaveFolder";
-            this._menuItemOpenMinecraftSaveFolder.Size = new System.Drawing.Size(223, 22);
+            this._menuItemOpenMinecraftSaveFolder.Size = new System.Drawing.Size(233, 22);
             this._menuItemOpenMinecraftSaveFolder.Text = "Open &Minecraft Save Folder";
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(220, 6);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(230, 6);
+            // 
+            // _menuItemSave
+            // 
+            this._menuItemSave.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemSave.Image")));
+            this._menuItemSave.Name = "_menuItemSave";
+            this._menuItemSave.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+            this._menuItemSave.Size = new System.Drawing.Size(233, 22);
+            this._menuItemSave.Text = "&Save";
+            // 
+            // _menuItemRefresh
+            // 
+            this._menuItemRefresh.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemRefresh.Image")));
+            this._menuItemRefresh.Name = "_menuItemRefresh";
+            this._menuItemRefresh.ShortcutKeys = System.Windows.Forms.Keys.F5;
+            this._menuItemRefresh.Size = new System.Drawing.Size(233, 22);
+            this._menuItemRefresh.Text = "Refresh";
+            this._menuItemRefresh.Click += new System.EventHandler(this.refreshToolStripMenuItem_Click);
             // 
             // toolStripSeparator4
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(220, 6);
+            this.toolStripSeparator4.Size = new System.Drawing.Size(230, 6);
             // 
             // _menuItemRecentFiles
             // 
             this._menuItemRecentFiles.Name = "_menuItemRecentFiles";
-            this._menuItemRecentFiles.Size = new System.Drawing.Size(223, 22);
+            this._menuItemRecentFiles.Size = new System.Drawing.Size(233, 22);
             this._menuItemRecentFiles.Text = "Recent Files";
             // 
             // _menuItemRecentFolders
             // 
             this._menuItemRecentFolders.Name = "_menuItemRecentFolders";
-            this._menuItemRecentFolders.Size = new System.Drawing.Size(223, 22);
+            this._menuItemRecentFolders.Size = new System.Drawing.Size(233, 22);
             this._menuItemRecentFolders.Text = "Recent Folders";
             // 
             // toolStripSeparator8
             // 
             this.toolStripSeparator8.Name = "toolStripSeparator8";
-            this.toolStripSeparator8.Size = new System.Drawing.Size(220, 6);
+            this.toolStripSeparator8.Size = new System.Drawing.Size(230, 6);
+            // 
+            // _menuItemExit
+            // 
+            this._menuItemExit.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemExit.Image")));
+            this._menuItemExit.Name = "_menuItemExit";
+            this._menuItemExit.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
+            this._menuItemExit.Size = new System.Drawing.Size(233, 22);
+            this._menuItemExit.Text = "E&xit";
             // 
             // editToolStripMenuItem
             // 
@@ -185,15 +231,81 @@
             this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
             this.editToolStripMenuItem.Text = "&Edit";
             // 
+            // _menuItemCut
+            // 
+            this._menuItemCut.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemCut.Image")));
+            this._menuItemCut.Name = "_menuItemCut";
+            this._menuItemCut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
+            this._menuItemCut.Size = new System.Drawing.Size(203, 22);
+            this._menuItemCut.Text = "Cu&t";
+            // 
+            // _menuItemCopy
+            // 
+            this._menuItemCopy.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemCopy.Image")));
+            this._menuItemCopy.Name = "_menuItemCopy";
+            this._menuItemCopy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+            this._menuItemCopy.Size = new System.Drawing.Size(203, 22);
+            this._menuItemCopy.Text = "&Copy";
+            // 
+            // _menuItemPaste
+            // 
+            this._menuItemPaste.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemPaste.Image")));
+            this._menuItemPaste.Name = "_menuItemPaste";
+            this._menuItemPaste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
+            this._menuItemPaste.Size = new System.Drawing.Size(203, 22);
+            this._menuItemPaste.Text = "&Paste";
+            // 
             // toolStripSeparator7
             // 
             this.toolStripSeparator7.Name = "toolStripSeparator7";
             this.toolStripSeparator7.Size = new System.Drawing.Size(200, 6);
             // 
+            // _menuItemRename
+            // 
+            this._menuItemRename.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemRename.Image")));
+            this._menuItemRename.Name = "_menuItemRename";
+            this._menuItemRename.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.R)));
+            this._menuItemRename.Size = new System.Drawing.Size(203, 22);
+            this._menuItemRename.Text = "&Rename";
+            // 
+            // _menuItemEditValue
+            // 
+            this._menuItemEditValue.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemEditValue.Image")));
+            this._menuItemEditValue.Name = "_menuItemEditValue";
+            this._menuItemEditValue.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
+            this._menuItemEditValue.Size = new System.Drawing.Size(203, 22);
+            this._menuItemEditValue.Text = "&Edit Value";
+            // 
+            // _menuItemDelete
+            // 
+            this._menuItemDelete.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemDelete.Image")));
+            this._menuItemDelete.Name = "_menuItemDelete";
+            this._menuItemDelete.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+            this._menuItemDelete.Size = new System.Drawing.Size(203, 22);
+            this._menuItemDelete.Text = "&Delete";
+            // 
             // toolStripSeparator10
             // 
             this.toolStripSeparator10.Name = "toolStripSeparator10";
             this.toolStripSeparator10.Size = new System.Drawing.Size(200, 6);
+            // 
+            // _menuItemMoveUp
+            // 
+            this._menuItemMoveUp.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemMoveUp.Image")));
+            this._menuItemMoveUp.Name = "_menuItemMoveUp";
+            this._menuItemMoveUp.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Up)));
+            this._menuItemMoveUp.Size = new System.Drawing.Size(203, 22);
+            this._menuItemMoveUp.Text = "Move &Up";
+            this._menuItemMoveUp.Click += new System.EventHandler(this._menuItemMoveUp_Click);
+            // 
+            // _menuItemMoveDown
+            // 
+            this._menuItemMoveDown.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemMoveDown.Image")));
+            this._menuItemMoveDown.Name = "_menuItemMoveDown";
+            this._menuItemMoveDown.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Down)));
+            this._menuItemMoveDown.Size = new System.Drawing.Size(203, 22);
+            this._menuItemMoveDown.Text = "Move Do&wn";
+            this._menuItemMoveDown.Click += new System.EventHandler(this._menuItemMoveDown_Click);
             // 
             // searchToolStripMenuItem
             // 
@@ -208,6 +320,22 @@
             this.searchToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
             this.searchToolStripMenuItem.Text = "&Search";
             // 
+            // _menuItemFind
+            // 
+            this._menuItemFind.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemFind.Image")));
+            this._menuItemFind.Name = "_menuItemFind";
+            this._menuItemFind.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
+            this._menuItemFind.Size = new System.Drawing.Size(167, 22);
+            this._menuItemFind.Text = "&Find...";
+            // 
+            // _menuItemFindNext
+            // 
+            this._menuItemFindNext.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemFindNext.Image")));
+            this._menuItemFindNext.Name = "_menuItemFindNext";
+            this._menuItemFindNext.ShortcutKeys = System.Windows.Forms.Keys.F3;
+            this._menuItemFindNext.Size = new System.Drawing.Size(167, 22);
+            this._menuItemFindNext.Text = "Find &Next";
+            // 
             // toolStripSeparator9
             // 
             this.toolStripSeparator9.Name = "toolStripSeparator9";
@@ -221,6 +349,18 @@
             this.replaceToolStripMenuItem.Text = "&Replace...";
             this.replaceToolStripMenuItem.Click += new System.EventHandler(this.replaceToolStripMenuItem_Click);
             // 
+            // toolStripSeparator11
+            // 
+            this.toolStripSeparator11.Name = "toolStripSeparator11";
+            this.toolStripSeparator11.Size = new System.Drawing.Size(164, 6);
+            // 
+            // findBlockToolStripMenuItem
+            // 
+            this.findBlockToolStripMenuItem.Name = "findBlockToolStripMenuItem";
+            this.findBlockToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.findBlockToolStripMenuItem.Text = "&Chunk Finder...";
+            this.findBlockToolStripMenuItem.Click += new System.EventHandler(this.findBlockToolStripMenuItem_Click);
+            // 
             // helpToolStripMenuItem
             // 
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -228,6 +368,14 @@
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpToolStripMenuItem.Text = "&Help";
+            // 
+            // _menuItemAbout
+            // 
+            this._menuItemAbout.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemAbout.Image")));
+            this._menuItemAbout.Name = "_menuItemAbout";
+            this._menuItemAbout.ShortcutKeys = System.Windows.Forms.Keys.F1;
+            this._menuItemAbout.Size = new System.Drawing.Size(126, 22);
+            this._menuItemAbout.Text = "&About";
             // 
             // imageList1
             // 
@@ -285,75 +433,6 @@
             this.toolStrip1.Stretch = true;
             this.toolStrip1.TabIndex = 0;
             // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
-            // 
-            // toolStripSeparator6
-            // 
-            this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(6, 25);
-            // 
-            // toolStripSeparator2
-            // 
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
-            // 
-            // toolStripSeparator5
-            // 
-            this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
-            // 
-            // BottomToolStripPanel
-            // 
-            this.BottomToolStripPanel.Location = new System.Drawing.Point(0, 0);
-            this.BottomToolStripPanel.Name = "BottomToolStripPanel";
-            this.BottomToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            this.BottomToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.BottomToolStripPanel.Size = new System.Drawing.Size(0, 0);
-            // 
-            // TopToolStripPanel
-            // 
-            this.TopToolStripPanel.Location = new System.Drawing.Point(0, 0);
-            this.TopToolStripPanel.Name = "TopToolStripPanel";
-            this.TopToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            this.TopToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.TopToolStripPanel.Size = new System.Drawing.Size(0, 0);
-            // 
-            // RightToolStripPanel
-            // 
-            this.RightToolStripPanel.Location = new System.Drawing.Point(0, 0);
-            this.RightToolStripPanel.Name = "RightToolStripPanel";
-            this.RightToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            this.RightToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.RightToolStripPanel.Size = new System.Drawing.Size(0, 0);
-            // 
-            // LeftToolStripPanel
-            // 
-            this.LeftToolStripPanel.Location = new System.Drawing.Point(0, 0);
-            this.LeftToolStripPanel.Name = "LeftToolStripPanel";
-            this.LeftToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            this.LeftToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.LeftToolStripPanel.Size = new System.Drawing.Size(0, 0);
-            // 
-            // ContentPanel
-            // 
-            this.ContentPanel.Size = new System.Drawing.Size(562, 376);
-            // 
-            // contextMenuStrip1
-            // 
-            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.testToolStripMenuItem});
-            this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(97, 26);
-            // 
-            // testToolStripMenuItem
-            // 
-            this.testToolStripMenuItem.Name = "testToolStripMenuItem";
-            this.testToolStripMenuItem.Size = new System.Drawing.Size(96, 22);
-            this.testToolStripMenuItem.Text = "Test";
-            // 
             // _buttonOpen
             // 
             this._buttonOpen.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -391,6 +470,11 @@
             this._buttonRefresh.Text = "Refresh Content From Disk";
             this._buttonRefresh.Click += new System.EventHandler(this._buttonRefresh_Click);
             // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            // 
             // _buttonCut
             // 
             this._buttonCut.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -418,6 +502,11 @@
             this._buttonPaste.Size = new System.Drawing.Size(23, 22);
             this._buttonPaste.Text = "Paste";
             // 
+            // toolStripSeparator6
+            // 
+            this.toolStripSeparator6.Name = "toolStripSeparator6";
+            this.toolStripSeparator6.Size = new System.Drawing.Size(6, 25);
+            // 
             // _buttonRename
             // 
             this._buttonRename.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -444,6 +533,11 @@
             this._buttonDelete.Name = "_buttonDelete";
             this._buttonDelete.Size = new System.Drawing.Size(23, 22);
             this._buttonDelete.Text = "Delete Tag";
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
             // 
             // _buttonAddTagByte
             // 
@@ -545,6 +639,11 @@
             this._buttonAddTagCompound.Size = new System.Drawing.Size(23, 22);
             this._buttonAddTagCompound.Text = "Add Compound Tag";
             // 
+            // toolStripSeparator5
+            // 
+            this.toolStripSeparator5.Name = "toolStripSeparator5";
+            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
+            // 
             // _buttonFindNext
             // 
             this._buttonFindNext.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -554,149 +653,68 @@
             this._buttonFindNext.Size = new System.Drawing.Size(23, 22);
             this._buttonFindNext.Text = "Find / Find Next";
             // 
-            // _menuItemOpen
+            // BottomToolStripPanel
             // 
-            this._menuItemOpen.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemOpen.Image")));
-            this._menuItemOpen.Name = "_menuItemOpen";
-            this._menuItemOpen.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this._menuItemOpen.Size = new System.Drawing.Size(223, 22);
-            this._menuItemOpen.Text = "&Open...";
+            this.BottomToolStripPanel.Location = new System.Drawing.Point(0, 0);
+            this.BottomToolStripPanel.Name = "BottomToolStripPanel";
+            this.BottomToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.BottomToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.BottomToolStripPanel.Size = new System.Drawing.Size(0, 0);
             // 
-            // _menuItemOpenFolder
+            // TopToolStripPanel
             // 
-            this._menuItemOpenFolder.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemOpenFolder.Image")));
-            this._menuItemOpenFolder.Name = "_menuItemOpenFolder";
-            this._menuItemOpenFolder.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
-            | System.Windows.Forms.Keys.O)));
-            this._menuItemOpenFolder.Size = new System.Drawing.Size(223, 22);
-            this._menuItemOpenFolder.Text = "Open &Folder...";
+            this.TopToolStripPanel.Location = new System.Drawing.Point(0, 0);
+            this.TopToolStripPanel.Name = "TopToolStripPanel";
+            this.TopToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.TopToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.TopToolStripPanel.Size = new System.Drawing.Size(0, 0);
             // 
-            // _menuItemSave
+            // RightToolStripPanel
             // 
-            this._menuItemSave.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemSave.Image")));
-            this._menuItemSave.Name = "_menuItemSave";
-            this._menuItemSave.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this._menuItemSave.Size = new System.Drawing.Size(223, 22);
-            this._menuItemSave.Text = "&Save";
+            this.RightToolStripPanel.Location = new System.Drawing.Point(0, 0);
+            this.RightToolStripPanel.Name = "RightToolStripPanel";
+            this.RightToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.RightToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.RightToolStripPanel.Size = new System.Drawing.Size(0, 0);
             // 
-            // _menuItemRefresh
+            // LeftToolStripPanel
             // 
-            this._menuItemRefresh.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemRefresh.Image")));
-            this._menuItemRefresh.Name = "_menuItemRefresh";
-            this._menuItemRefresh.ShortcutKeys = System.Windows.Forms.Keys.F5;
-            this._menuItemRefresh.Size = new System.Drawing.Size(223, 22);
-            this._menuItemRefresh.Text = "Refresh";
-            this._menuItemRefresh.Click += new System.EventHandler(this.refreshToolStripMenuItem_Click);
+            this.LeftToolStripPanel.Location = new System.Drawing.Point(0, 0);
+            this.LeftToolStripPanel.Name = "LeftToolStripPanel";
+            this.LeftToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.LeftToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.LeftToolStripPanel.Size = new System.Drawing.Size(0, 0);
             // 
-            // _menuItemExit
+            // ContentPanel
             // 
-            this._menuItemExit.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemExit.Image")));
-            this._menuItemExit.Name = "_menuItemExit";
-            this._menuItemExit.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-            this._menuItemExit.Size = new System.Drawing.Size(223, 22);
-            this._menuItemExit.Text = "E&xit";
+            this.ContentPanel.Size = new System.Drawing.Size(562, 376);
             // 
-            // _menuItemCut
+            // contextMenuStrip1
             // 
-            this._menuItemCut.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemCut.Image")));
-            this._menuItemCut.Name = "_menuItemCut";
-            this._menuItemCut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-            this._menuItemCut.Size = new System.Drawing.Size(203, 22);
-            this._menuItemCut.Text = "Cu&t";
+            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.testToolStripMenuItem});
+            this.contextMenuStrip1.Name = "contextMenuStrip1";
+            this.contextMenuStrip1.Size = new System.Drawing.Size(97, 26);
             // 
-            // _menuItemCopy
+            // testToolStripMenuItem
             // 
-            this._menuItemCopy.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemCopy.Image")));
-            this._menuItemCopy.Name = "_menuItemCopy";
-            this._menuItemCopy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this._menuItemCopy.Size = new System.Drawing.Size(203, 22);
-            this._menuItemCopy.Text = "&Copy";
+            this.testToolStripMenuItem.Name = "testToolStripMenuItem";
+            this.testToolStripMenuItem.Size = new System.Drawing.Size(96, 22);
+            this.testToolStripMenuItem.Text = "Test";
             // 
-            // _menuItemPaste
+            // toolStripSeparator12
             // 
-            this._menuItemPaste.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemPaste.Image")));
-            this._menuItemPaste.Name = "_menuItemPaste";
-            this._menuItemPaste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this._menuItemPaste.Size = new System.Drawing.Size(203, 22);
-            this._menuItemPaste.Text = "&Paste";
+            this.toolStripSeparator12.Name = "toolStripSeparator12";
+            this.toolStripSeparator12.Size = new System.Drawing.Size(230, 6);
             // 
-            // _menuItemRename
+            // _menuItemOpenInExplorer
             // 
-            this._menuItemRename.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemRename.Image")));
-            this._menuItemRename.Name = "_menuItemRename";
-            this._menuItemRename.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.R)));
-            this._menuItemRename.Size = new System.Drawing.Size(203, 22);
-            this._menuItemRename.Text = "&Rename";
-            // 
-            // _menuItemEditValue
-            // 
-            this._menuItemEditValue.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemEditValue.Image")));
-            this._menuItemEditValue.Name = "_menuItemEditValue";
-            this._menuItemEditValue.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
-            this._menuItemEditValue.Size = new System.Drawing.Size(203, 22);
-            this._menuItemEditValue.Text = "&Edit Value";
-            // 
-            // _menuItemDelete
-            // 
-            this._menuItemDelete.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemDelete.Image")));
-            this._menuItemDelete.Name = "_menuItemDelete";
-            this._menuItemDelete.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-            this._menuItemDelete.Size = new System.Drawing.Size(203, 22);
-            this._menuItemDelete.Text = "&Delete";
-            // 
-            // _menuItemMoveUp
-            // 
-            this._menuItemMoveUp.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemMoveUp.Image")));
-            this._menuItemMoveUp.Name = "_menuItemMoveUp";
-            this._menuItemMoveUp.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Up)));
-            this._menuItemMoveUp.Size = new System.Drawing.Size(203, 22);
-            this._menuItemMoveUp.Text = "Move &Up";
-            this._menuItemMoveUp.Click += new System.EventHandler(this._menuItemMoveUp_Click);
-            // 
-            // _menuItemMoveDown
-            // 
-            this._menuItemMoveDown.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemMoveDown.Image")));
-            this._menuItemMoveDown.Name = "_menuItemMoveDown";
-            this._menuItemMoveDown.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Down)));
-            this._menuItemMoveDown.Size = new System.Drawing.Size(203, 22);
-            this._menuItemMoveDown.Text = "Move Do&wn";
-            this._menuItemMoveDown.Click += new System.EventHandler(this._menuItemMoveDown_Click);
-            // 
-            // _menuItemFind
-            // 
-            this._menuItemFind.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemFind.Image")));
-            this._menuItemFind.Name = "_menuItemFind";
-            this._menuItemFind.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this._menuItemFind.Size = new System.Drawing.Size(167, 22);
-            this._menuItemFind.Text = "&Find...";
-            // 
-            // _menuItemFindNext
-            // 
-            this._menuItemFindNext.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemFindNext.Image")));
-            this._menuItemFindNext.Name = "_menuItemFindNext";
-            this._menuItemFindNext.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this._menuItemFindNext.Size = new System.Drawing.Size(167, 22);
-            this._menuItemFindNext.Text = "Find &Next";
-            // 
-            // _menuItemAbout
-            // 
-            this._menuItemAbout.Image = ((System.Drawing.Image)(resources.GetObject("_menuItemAbout.Image")));
-            this._menuItemAbout.Name = "_menuItemAbout";
-            this._menuItemAbout.ShortcutKeys = System.Windows.Forms.Keys.F1;
-            this._menuItemAbout.Size = new System.Drawing.Size(126, 22);
-            this._menuItemAbout.Text = "&About";
-            // 
-            // toolStripSeparator11
-            // 
-            this.toolStripSeparator11.Name = "toolStripSeparator11";
-            this.toolStripSeparator11.Size = new System.Drawing.Size(164, 6);
-            // 
-            // findBlockToolStripMenuItem
-            // 
-            this.findBlockToolStripMenuItem.Name = "findBlockToolStripMenuItem";
-            this.findBlockToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
-            this.findBlockToolStripMenuItem.Text = "&Chunk Finder...";
-            this.findBlockToolStripMenuItem.Click += new System.EventHandler(this.findBlockToolStripMenuItem_Click);
+            this._menuItemOpenInExplorer.Enabled = false;
+            this._menuItemOpenInExplorer.Name = "_menuItemOpenInExplorer";
+            this._menuItemOpenInExplorer.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            | System.Windows.Forms.Keys.E)));
+            this._menuItemOpenInExplorer.Size = new System.Drawing.Size(233, 22);
+            this._menuItemOpenInExplorer.Text = "Open in &Explorer";
             // 
             // _nodeTree
             // 
@@ -809,6 +827,8 @@
         private System.Windows.Forms.ToolStripMenuItem _menuItemMoveDown;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
         private System.Windows.Forms.ToolStripMenuItem findBlockToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
+        private System.Windows.Forms.ToolStripMenuItem _menuItemOpenInExplorer;
     }
 }
 

--- a/NBTExplorer/Windows/MainForm.cs
+++ b/NBTExplorer/Windows/MainForm.cs
@@ -101,6 +101,7 @@ namespace NBTExplorer.Windows
             _menuItemFind.Click += _menuItemFind_Click;
             _menuItemFindNext.Click += _menuItemFindNext_Click;
             _menuItemAbout.Click += _menuItemAbout_Click;
+            _menuItemOpenInExplorer.Click += _menuItemOpenInExplorer_Click;
 
             string[] args = Environment.GetCommandLineArgs();
             if (args.Length > 1) {
@@ -113,6 +114,18 @@ namespace NBTExplorer.Windows
             }
 
             UpdateOpenMenu();
+        }
+
+        void _menuItemOpenInExplorer_Click(object sender, EventArgs e)
+        {
+            if (_nodeTree.SelectedNode.Tag is DirectoryDataNode) {
+                DirectoryDataNode ddNode = _nodeTree.SelectedNode.Tag as DirectoryDataNode;
+                try {
+                    System.Diagnostics.Process.Start(ddNode.NodeDirPath);
+                } catch (Win32Exception ex) {
+                    MessageBox.Show(ex.Message, "Can't open directory", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
         }
 
         private void InitializeIconRegistry ()
@@ -480,6 +493,7 @@ namespace NBTExplorer.Windows
             _menuItemFindNext.Enabled = _searchState != null;
             _menuItemMoveUp.Enabled = node.CanMoveNodeUp;
             _menuItemMoveDown.Enabled = node.CanMoveNodeDown;
+            _menuItemOpenInExplorer.Enabled = node is DirectoryDataNode;
 
             UpdateUI(_nodeTree.SelectedNodes);
         }


### PR DESCRIPTION
1. I added an alternative to the Windows folder browser dialog because I hate that dialog. You can hold down Control while clicking the Open Folder menu item to use a standard file open dialog, and it just uses the directory containing whichever file you selected. It won't interfere with the keyboard shortcut (Ctrl+Shift+O), as it won't do it if you're also holding Shift.
2. I also added a menu item to open the currently-selected directory in Explorer, a feature I thought was missing.
