### PR TITLE
Add new sort order to NBT Tree view.

### DIFF
--- a/NBTExplorer/Controllers/NodeTreeController.cs
+++ b/NBTExplorer/Controllers/NodeTreeController.cs
@@ -6,6 +6,7 @@ using NBTExplorer.Model;
 using NBTExplorer.Vendor.MultiSelectTreeView;
 using NBTExplorer.Windows;
 using Substrate.Nbt;
+using System.Collections;
 
 namespace NBTExplorer.Controllers
 {
@@ -17,6 +18,56 @@ namespace NBTExplorer.Controllers
         public MessageBoxEventArgs (string message)
         {
             Message = message;
+        }
+    }
+
+    public class NodeTreeComparer : IComparer
+    {
+        public int orderForTag(TagType tagID)
+        {
+            switch (tagID)
+            {
+                case TagType.TAG_COMPOUND:
+                    return 0;
+                case TagType.TAG_LIST:
+                    return 1;
+                case TagType.TAG_BYTE:
+                case TagType.TAG_SHORT:
+                case TagType.TAG_INT:
+                case TagType.TAG_LONG:
+                case TagType.TAG_FLOAT:
+                case TagType.TAG_DOUBLE:
+                case TagType.TAG_STRING:
+                    return 2;
+                default:
+                    return 3;
+            }
+        }
+
+        public int Compare(object x, object y)
+        {
+            TreeNode tx = x as TreeNode;
+            TreeNode ty = y as TreeNode;
+            TagDataNode dx = tx.Tag as TagDataNode;
+            TagDataNode dy = ty.Tag as TagDataNode;
+
+            if (dx == null || dy == null)
+            {
+                return tx.Text.CompareTo(ty.Text);
+            }
+
+            TagType idx = dx.Tag.GetTagType();
+            TagType idy = dy.Tag.GetTagType();
+            int tagOrder = this.orderForTag(idx).CompareTo(this.orderForTag(idy));
+            if (tagOrder != 0)
+            {
+                return tagOrder;
+            } 
+            else 
+            {
+                return dx.NodeDisplay.CompareTo(dy.NodeDisplay);
+            }
+            
         }
     }
 
@@ -33,6 +84,7 @@ namespace NBTExplorer.Controllers
         public NodeTreeController (TreeView nodeTree)
         {
             _nodeTree = nodeTree;
+            nodeTree.TreeViewNodeSorter = new NodeTreeComparer();
             _multiTree = nodeTree as MultiSelectTreeView;
 
             InitializeIconRegistry();

--- a/NBTExplorer/Controllers/NodeTreeController.cs
+++ b/NBTExplorer/Controllers/NodeTreeController.cs
@@ -23,7 +23,7 @@ namespace NBTExplorer.Controllers
 
     public class NodeTreeComparer : IComparer
     {
-        public int orderForTag(TagType tagID)
+        public int OrderForTag(TagType tagID)
         {
             switch (tagID)
             {
@@ -44,6 +44,18 @@ namespace NBTExplorer.Controllers
             }
         }
 
+        public int OrderForNode(object node)
+        {
+            if (node is DirectoryDataNode)
+            {
+                return 0;
+            }
+            else
+            {
+                return 1;
+            }
+        }
+
         public int Compare(object x, object y)
         {
             TreeNode tx = x as TreeNode;
@@ -53,12 +65,20 @@ namespace NBTExplorer.Controllers
 
             if (dx == null || dy == null)
             {
-                return tx.Text.CompareTo(ty.Text);
+                int nodeOrder = this.OrderForNode(tx.Tag).CompareTo(this.OrderForNode(ty.Tag));
+                if (nodeOrder != 0)
+                {
+                    return nodeOrder;
+                }
+                else
+                {
+                    return tx.Text.CompareTo(ty.Text);
+                }
             }
 
             TagType idx = dx.Tag.GetTagType();
             TagType idy = dy.Tag.GetTagType();
-            int tagOrder = this.orderForTag(idx).CompareTo(this.orderForTag(idy));
+            int tagOrder = this.OrderForTag(idx).CompareTo(this.OrderForTag(idy));
             if (tagOrder != 0)
             {
                 return tagOrder;


### PR DESCRIPTION
Enforce a new sorting order for Tag nodes in the NBT tree view:

- Compounds
- Lists
- All non-array types, ordered by tag name
- Array types

Non-Tag nodes are ordered with directory nodes first. Let me know if I missed anything.

As described in #24