### PR TITLE
When sorting the children of a TAG_LIST, preserve the original order.

### DIFF
--- a/NBTExplorer/Controllers/NodeTreeController.cs
+++ b/NBTExplorer/Controllers/NodeTreeController.cs
@@ -79,6 +79,16 @@ namespace NBTExplorer.Controllers
                 }
             }
 
+            TagDataNode px = dx.Parent as TagDataNode;
+            TagDataNode py = dy.Parent as TagDataNode;
+            if (px != null && py != null)
+            {
+                if (px.Tag.GetTagType() == TagType.TAG_LIST || py.Tag.GetTagType() == TagType.TAG_LIST)
+                {
+                    return 0;
+                }
+            }
+
             TagType idx = dx.Tag.GetTagType();
             TagType idy = dy.Tag.GetTagType();
             int tagOrder = this.OrderForTag(idx).CompareTo(this.OrderForTag(idy));


### PR DESCRIPTION
Adding the NodeTreeComparer to the tree view had the incorrect result of reordering the children of a TAG_List. This is wrong, since order matters for lists. In addition, the "Move Up" and "Move Down" context menu commands appear to have no effect.

The documentation for TreeViewNodeSorter says:
```The default sorter uses the Compare method based on the CurrentCulture specified by the application. This means that TreeNode objects with equal value are kept in the order in which they were added to the TreeView control. This behavior may be different if a custom sort is applied.```

This suggests that the tree view uses a stable sort when calling the NodeTreeComparer, which means returning 0 will keep the order they have in the node graph. If it isn't the case that a stable sort is used, it could instead call mumble.OrderedTagContainer.GetTagIndex and sort on that, which seems kind of redundant.

Anyway, this patch appears to fix this problem, since the Move Up and Move Down work as expected and the elements of a player's Position are in the right order again.