### PR TITLE
Allow pasting tags to an empty List. Converts the list's type.

### DIFF
--- a/NBTModel/Data/Nodes/TagListDataNode.cs
+++ b/NBTModel/Data/Nodes/TagListDataNode.cs
@@ -46,7 +46,7 @@ namespace NBTExplorer.Model
                     if (data == null)
                         return false;
 
-                    if (data.Node != null && data.Node.GetTagType() == Tag.ValueType)
+                    if (data.Node != null && (data.Node.GetTagType() == Tag.ValueType || Tag.Count == 0))
                         return true;
                 }
 
@@ -75,6 +75,10 @@ namespace NBTExplorer.Model
             NbtClipboardData clipboard = NbtClipboardController.CopyFromClipboard();
             if (clipboard == null || clipboard.Node == null)
                 return false;
+
+            if (Tag.Count == 0) {
+                Tag.ChangeValueType(clipboard.Node.GetTagType());
+            }
 
             AppendTag(clipboard.Node);
             return true;


### PR DESCRIPTION
From quick testing it seems to work. Hopefully I didn't break something else with this.
(Just installed Visual Studio for this and this is my first contact with C# / Mono or whatever language this is ;p)

Edit: Oh yeah, fixes #20.