### PR TITLE
When opening files directly, try opening as NBT if no registered filetypes were able to open them.

### DIFF
--- a/NBTExplorer/Controllers/NodeTreeController.cs
+++ b/NBTExplorer/Controllers/NodeTreeController.cs
@@ -231,6 +231,8 @@ namespace NBTExplorer.Controllers
                             node = item.Value.NodeCreate(path);
                     }
 
+                    if (node == null)
+                        node = NbtFileDataNode.TryCreateFrom(path);
                     if (node != null)
                         _nodeTree.Nodes.Add(CreateUnexpandedNode(node));
                     else


### PR DESCRIPTION
This change allows NBT files with any extension to be opened via command line (i.e. through file associations in Finder, Windows Explorer, etc), dragged-and-dropped into the NBTExplorer window, and opened with the "Open..." menu command and toolbar icon. It shouldn't affect the performance of directory views.

This allows associating *.bpt, *.rs, *.thaum, and other extensions with NBTExplorer.

Fixes #31.
