### PR TITLE
Add schem files

### DIFF
--- a/NBTExplorer/Windows/MainForm.cs
+++ b/NBTExplorer/Windows/MainForm.cs
@@ -165,7 +165,7 @@ namespace NBTExplorer.Windows
             using (OpenFileDialog ofd = new OpenFileDialog() {
                 RestoreDirectory = true,
                 Multiselect = true,
-                Filter = "All Files|*|NBT Files (*.dat, *.schematic)|*.dat;*.nbt;*.schematic|Region Files (*.mca, *.mcr)|*.mca;*.mcr",
+                Filter = "All Files|*|NBT Files (*.dat, *.schematic)|*.dat;*.nbt;*.schematic;*.schem|Region Files (*.mca, *.mcr)|*.mca;*.mcr",
                 FilterIndex = 0,
             }) {
                 if (ofd.ShowDialog() == DialogResult.OK) {

--- a/NBTModel/Data/Nodes/NbtFileDataNode.cs
+++ b/NBTModel/Data/Nodes/NbtFileDataNode.cs
@@ -16,7 +16,7 @@ namespace NBTExplorer.Model
 
         private CompoundTagContainer _container;
 
-        private static Regex _namePattern = new Regex(@"\.(dat|nbt|schematic|dat_mcr|dat_old|bpt|rc)$");
+        private static Regex _namePattern = new Regex(@"\.(dat|nbt|schem(atic)?|dat_mcr|dat_old|bpt|rc)$");
 
         private NbtFileDataNode (string path, CompressionType compressionType)
         {


### PR DESCRIPTION
`.schem` is the file extension used by the [Sponge Schematic](https://github.com/SpongePowered/Schematic-Specification) format, used by Sponge, WorldEdit, etc. They're just gzip'd nbt like any other, so nothing else is needed to support them. This just adds the file extension so they are recognized as nbt files by default in the UI.