### PR TITLE
Add --delete flag to aid trimming worlds

### DIFF
--- a/NBTUtil/ConsoleOptions.cs
+++ b/NBTUtil/ConsoleOptions.cs
@@ -56,6 +56,7 @@ namespace NBTUtil
                     if (!string.IsNullOrEmpty(v))
                         Values.Add(v);
                 }},
+                { "delete", "Delete the NBT tag if found", v => Command = ConsoleCommand.DeleteValue },
                 { "help", "Print this help message", v => Command = ConsoleCommand.Help },
                 { "<>", v => {
                     switch (_currentKey) {
@@ -65,7 +66,6 @@ namespace NBTUtil
                             break;
                     }
                 }},
-                { "delete", "Delete the NBT tag if found", v => Command = ConsoleCommand.DeleteValue },
             };
         }
 

--- a/NBTUtil/ConsoleOptions.cs
+++ b/NBTUtil/ConsoleOptions.cs
@@ -11,6 +11,7 @@ namespace NBTUtil
         Print,
         PrintTree,
         SetValue,
+        DeleteValue,
         SetList,
         Json,
         Help,
@@ -64,6 +65,7 @@ namespace NBTUtil
                             break;
                     }
                 }},
+                { "delete", "Delete the NBT tag if found", v => Command = ConsoleCommand.DeleteValue },
             };
         }
 

--- a/NBTUtil/ConsoleRunner.cs
+++ b/NBTUtil/ConsoleRunner.cs
@@ -45,17 +45,30 @@ namespace NBTUtil
             int successCount = 0;
             int failCount = 0;
 
-            foreach (var targetNode in new NbtPathEnumerator(_options.Path)) {
-                if (!op.CanProcess(targetNode)) {
-                    Console.WriteLine(targetNode.NodePath + ": ERROR (invalid command)");
+            var nodesToProcess = new List<DataNode>();
+
+            foreach (var node in new NbtPathEnumerator(_options.Path))
+            {
+                if (op.CanProcess(node))
+                {
+                    nodesToProcess.Add(node);
+                }
+                else
+                {
+                    Console.WriteLine(node.NodePath + ": ERROR (invalid command)");
                     failCount++;
                 }
+            }
+
+            foreach (var targetNode in nodesToProcess) {
+                var root = targetNode.Root;
+
                 if (!op.Process(targetNode, _options)) {
                     Console.WriteLine(targetNode.NodePath + ": ERROR (apply)");
                     failCount++;
                 }
 
-                targetNode.Root.Save();
+                root.Save();
 
                 Console.WriteLine(targetNode.NodePath + ": OK");
                 successCount++;

--- a/NBTUtil/ConsoleRunner.cs
+++ b/NBTUtil/ConsoleRunner.cs
@@ -13,6 +13,7 @@ namespace NBTUtil
     {
         private static readonly Dictionary<ConsoleCommand, ConsoleOperation> _commandTable = new Dictionary<ConsoleCommand, ConsoleOperation>() {
             { ConsoleCommand.SetValue, new EditOperation() },
+            { ConsoleCommand.DeleteValue, new DeleteOperation() },
             { ConsoleCommand.SetList, new SetListOperation() },
             { ConsoleCommand.Print, new PrintOperation() },
             { ConsoleCommand.PrintTree, new PrintTreeOperation() },

--- a/NBTUtil/NBTUtil.csproj
+++ b/NBTUtil/NBTUtil.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ConsoleRunner.cs" />
     <Compile Include="NDesk\Options.cs" />
     <Compile Include="Ops\ConsoleOperation.cs" />
+    <Compile Include="Ops\DeleteOperation.cs" />
     <Compile Include="Ops\EditOperation.cs" />
     <Compile Include="Ops\JsonOperation.cs" />
     <Compile Include="Ops\PrintOperation.cs" />

--- a/NBTUtil/Ops/DeleteOperation.cs
+++ b/NBTUtil/Ops/DeleteOperation.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NBTExplorer.Model;
+
+namespace NBTUtil.Ops
+{
+    class DeleteOperation : ConsoleOperation
+    {
+        public override bool OptionsValid (ConsoleOptions options)
+        {
+            return true;
+        }
+
+        public override bool CanProcess (DataNode dataNode)
+        {
+            return (dataNode != null) && dataNode.CanDeleteNode && (dataNode.Root != dataNode);
+        }
+
+        public override bool Process (DataNode dataNode, ConsoleOptions options)
+        {
+            return dataNode.DeleteNode();
+        }
+    }
+}


### PR DESCRIPTION
When a new version of the game comes along, it is useful to be able to delete chunks based on some criteria, like `InhabitedTime` being 0.

This change adds a `--delete` flag to NBTUtil that deletes the node or nodes specified by `--path`. It also restructures how the nodes were iterated over to allow them to be deleted.

NBTUtil can then be wrapped in a script that reads the data from each chunk and calls NBTUtil --delete on the chunk if the criteria are met.