### PR TITLE
- display whole file path for the root element (if applicable)

### DIFF
--- a/NBTModel/Data/Nodes/AbstractFileDataNode.cs
+++ b/NBTModel/Data/Nodes/AbstractFileDataNode.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+
+namespace NBTExplorer.Model
+{
+  /// <summary>
+  /// Common functionality for a few nodes that represent files.
+  /// </summary>
+  public class AbstractFileDataNode : DataNode
+  {
+    protected string _path;
+
+    protected AbstractFileDataNode(string path)
+    {
+      _path = path;
+    }
+
+    /// <summary>
+    /// Not only the name of the node but also (in some cases, but not all) the value (or part of the value) that is displayed to the user.
+    /// Return the full path if this node is the root, otherwise return only the file/folder name
+    /// </summary>
+    public override string NodeName
+    {
+      get => Parent == null ? _path : Path.GetFileName(_path);
+    }
+
+    /// <summary>
+    /// Just return NodeName, since that is where the display name is build.
+    /// Side note: I believe NodeName and NodeDisplay should be separated, this would then allow to replace NodePathName with NodeName, but that
+    /// would require changing a lot of unfamiliar (to me) code.
+    /// </summary>
+    public override string NodeDisplay
+    {
+      get => NodeName;
+    }
+
+    /// <summary>
+    /// The actual name of the node in a path. Return only the name of the file or folder, not the whole path.
+    /// </summary>
+    public override string NodePathName
+    {
+      get => Path.GetFileName(_path);
+    }
+  }
+}

--- a/NBTModel/Data/Nodes/CubicRegionDataNode.cs
+++ b/NBTModel/Data/Nodes/CubicRegionDataNode.cs
@@ -5,17 +5,14 @@ using NBTModel.Interop;
 
 namespace NBTExplorer.Model
 {
-    public class CubicRegionDataNode : DataNode
-    {
-        private string _path;
+    public class CubicRegionDataNode : AbstractFileDataNode
+  {
         private CubicRegionFile _region;
 
         private static Regex _namePattern = new Regex(@"^r2(\.-?\d+){3}\.(mcr|mca)$");
 
-        private CubicRegionDataNode (string path)
-        {
-            _path = path;
-        }
+        private CubicRegionDataNode (string path) : base(path)
+        {}
 
         public static CubicRegionDataNode TryCreateFrom (string path)
         {
@@ -45,16 +42,6 @@ namespace NBTExplorer.Model
         public override bool IsContainerType
         {
             get { return true; }
-        }
-
-        public override string NodePathName
-        {
-            get { return Path.GetFileName(_path); }
-        }
-
-        public override string NodeDisplay
-        {
-            get { return Path.GetFileName(_path); }
         }
 
         protected override void ExpandCore ()

--- a/NBTModel/Data/Nodes/DirectoryDataNode.cs
+++ b/NBTModel/Data/Nodes/DirectoryDataNode.cs
@@ -4,14 +4,10 @@ using System;
 
 namespace NBTExplorer.Model
 {
-    public class DirectoryDataNode : DataNode
+    public class DirectoryDataNode : AbstractFileDataNode
     {
-        private string _path;
-
-        public DirectoryDataNode (string path)
-        {
-            _path = path;
-        }
+        public DirectoryDataNode (string path) : base(path)
+        {}
 
         protected override NodeCapabilities Capabilities
         {
@@ -38,11 +34,6 @@ namespace NBTExplorer.Model
 
                 return (sepIndex > 0) ? name.Substring(sepIndex + 1) : name;
             }
-        }
-
-        public override string NodeDisplay
-        {
-            get { return Path.GetFileName(_path); }
         }
 
         public override bool HasUnexpandedChildren

--- a/NBTModel/Data/Nodes/NbtFileDataNode.cs
+++ b/NBTModel/Data/Nodes/NbtFileDataNode.cs
@@ -8,19 +8,17 @@ using NBTModel.Interop;
 
 namespace NBTExplorer.Model
 {
-    public class NbtFileDataNode : DataNode, IMetaTagContainer
+    public class NbtFileDataNode : AbstractFileDataNode, IMetaTagContainer
     {
         private NbtTree _tree;
-        private string _path;
         private CompressionType _compressionType;
 
         private CompoundTagContainer _container;
 
         private static Regex _namePattern = new Regex(@"\.(dat|nbt|schematic|dat_mcr|dat_old|bpt|rc)$");
 
-        private NbtFileDataNode (string path, CompressionType compressionType)
+        private NbtFileDataNode (string path, CompressionType compressionType) : base(path)
         {
-            _path = path;
             _compressionType = compressionType;
             _container = new CompoundTagContainer(new TagNodeCompound());
         }
@@ -64,16 +62,6 @@ namespace NBTExplorer.Model
                     | NodeCapabilities.Refresh
                     | NodeCapabilities.Rename;
             }
-        }
-
-        public override string NodeName
-        {
-            get { return Path.GetFileName(_path); }
-        }
-
-        public override string NodePathName
-        {
-            get { return Path.GetFileName(_path); }
         }
 
         public override string NodeDisplay

--- a/NBTModel/Data/Nodes/RegionFileDataNode.cs
+++ b/NBTModel/Data/Nodes/RegionFileDataNode.cs
@@ -7,18 +7,15 @@ using System;
 
 namespace NBTExplorer.Model
 {
-    public class RegionFileDataNode : DataNode
+    public class RegionFileDataNode : AbstractFileDataNode
     {
-        private string _path;
         private RegionFile _region;
         private List<RegionKey> _deleteQueue = new List<RegionKey>();
 
         private static Regex _namePattern = new Regex(@"^r\.(-?\d+)\.(-?\d+)\.(mcr|mca)$");
 
-        private RegionFileDataNode (string path)
-        {
-            _path = path;
-        }
+        private RegionFileDataNode (string path) : base(path)
+        {}
 
         public static RegionFileDataNode TryCreateFrom (string path)
         {
@@ -62,16 +59,6 @@ namespace NBTExplorer.Model
         public override bool IsContainerType
         {
             get { return true; }
-        }
-
-        public override string NodePathName
-        {
-            get { return Path.GetFileName(_path); }
-        }
-
-        public override string NodeDisplay
-        {
-            get { return Path.GetFileName(_path); }
         }
 
         protected override void ExpandCore ()

--- a/NBTModel/NBTModel.csproj
+++ b/NBTModel/NBTModel.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Data\CompoundTagContainer.cs" />
+    <Compile Include="Data\Nodes\AbstractFileDataNode.cs" />
     <Compile Include="Data\Nodes\CubicRegionDataNode.cs" />
     <Compile Include="Data\CubicRegionFile.cs" />
     <Compile Include="Data\Nodes\DataNode.cs" />


### PR DESCRIPTION
This shows the whole path for the root element if a file or folder is opened (including the default minecraft folder), so the user can tell which files they are currently viewing. I created a base class to handle this and all of the four classes i found that use a file as their base now inherit this new AbstractFileDataNode instead of the DataNode.

The reason i did this was because i am currently using NBTExplorer to view a lot of region files for another project and it becomes hard to remember which windows has what file open. Now i don't need to remember, i can just look at the root node.