### PR TITLE
Allow copying the data off of NBT files (i.e playerdata .dat files) into the clipboard.

### DIFF
--- a/NBTModel/Data/Nodes/NbtFileDataNode.cs
+++ b/NBTModel/Data/Nodes/NbtFileDataNode.cs
@@ -59,6 +59,7 @@ namespace NBTExplorer.Model
             get
             {
                 return NodeCapabilities.CreateTag
+                    | NodeCapabilities.Copy
                     | NodeCapabilities.PasteInto
                     | NodeCapabilities.Search
                     | NodeCapabilities.Refresh
@@ -71,9 +72,15 @@ namespace NBTExplorer.Model
             get { return Path.GetFileName(_path); }
         }
 
+
         public override string NodePathName
         {
             get { return Path.GetFileName(_path); }
+        }
+
+        private string NodeNameWithoutExtension
+        {
+            get { return Path.GetFileNameWithoutExtension(_path); }
         }
 
         public override string NodeDisplay
@@ -99,6 +106,27 @@ namespace NBTExplorer.Model
         public override bool IsContainerType
         {
             get { return true; }
+        }
+
+        private TagNodeCompound GetTagNode ()
+        {
+            TagNode tag;
+
+            if (_tree == null) {
+                try {
+                    Expand();
+                    tag = _tree.Root.Copy();
+                    Release();
+                }
+                catch {
+                    Release();
+                    return null;
+                }
+            }
+            else {
+                tag = _tree.Root.Copy();
+            }
+            return (TagNodeCompound) tag;
         }
 
         protected override void ExpandCore ()
@@ -198,6 +226,20 @@ namespace NBTExplorer.Model
                     AddTag(data.TagNode, data.TagName);
                     return true;
                 }
+            }
+
+            return false;
+        }
+
+        public override bool CopyNode()
+        {
+            if (CanCopyNode)
+            {
+                // Need to create new compound tag, add all children of the nbt node into it,
+                // copy it and delete it.
+                
+                NbtClipboardController.CopyToClipboard(new NbtClipboardData(this.NodeNameWithoutExtension, this.GetTagNode()));
+                return true;
             }
 
             return false;


### PR DESCRIPTION
Straight to the point, this pull request adds a feature I've needed dozens of times before. The feature is, the ability to copy entire .dat files as if they were compound tags, and paste them elsewhere.

This feature is incredibly useful when hosting a LAN world and sharing the world folder between friends, because if not corrected the game will overwrite the new host player's inventory with the old host's inventory. To prevent this, one needs to open the world with NBTExplorer, copy the data from their personal file in the playerdata folder, and overwrite the level.dat file's "Player" entry with the data. It's incredibly hard to do this without being able to copy data from .dat files.

I would very much prefer it if this pr got merged, but as this repository hasn't been updated in years, I will also include an executable in my fork's releases page.